### PR TITLE
use sdfat's directory and file-indexing functions

### DIFF
--- a/MaxDuino.ino
+++ b/MaxDuino.ino
@@ -160,11 +160,10 @@ char fline[17];
 SdFat sd;                           //Initialise Sd card 
 SdBaseFile entry, currentDir, tmpdir;                       //SD card file and directory
 
-#define subdirLength     22         // hasta 62 no incrementa el consumo de RAM
-#define filenameLength   8*subdirLength  //Maximum length for scrolling filename, hasta 255 no incrementa consumo RAM
+#define filenameLength 256
 
 char fileName[filenameLength + 1];    //Current filename
-#define nMaxPrevSubDirs 6
+#define nMaxPrevSubDirs 10
 char prevSubDir[SCREENSIZE+1];
 uint16_t DirFilePos[nMaxPrevSubDirs];  //File Positions in Directory to be restored (also, history of subdirectories)
 byte subdir = 0;

--- a/MaxDuino.ino
+++ b/MaxDuino.ino
@@ -158,17 +158,15 @@
 char fline[17];
 
 SdFat sd;                           //Initialise Sd card 
-SdBaseFile entry;                       //SD card file
+SdBaseFile entry, currentDir, tmpdir;                       //SD card file and directory
 
 #define subdirLength     22         // hasta 62 no incrementa el consumo de RAM
 #define filenameLength   8*subdirLength  //Maximum length for scrolling filename, hasta 255 no incrementa consumo RAM
 
 char fileName[filenameLength + 1];    //Current filename
-char sfileName[13];                   //Short filename variable
-
 #define nMaxPrevSubDirs 6
-char prevSubDir[nMaxPrevSubDirs][subdirLength];    // Subir a la EPROM ¿?
-int DirFilePos[nMaxPrevSubDirs];                   //File Position in Directory to be restored
+char prevSubDir[SCREENSIZE+1];
+uint16_t DirFilePos[nMaxPrevSubDirs];  //File Positions in Directory to be restored (also, history of subdirectories)
 byte subdir = 0;
 unsigned long filesize;             // filesize used for dimensioning AY files
 
@@ -181,10 +179,10 @@ byte oldMotorState = 1;             //Last motor control state
 byte start = 0;                     //Currently playing flag
 
 byte pauseOn = 0;                   //Pause state
-int currentFile = 1;                //Current position in directory
-int maxFile = 0;                    //Total number of files in directory
-int oldMinFile = 1;
-int oldMaxFile = 0;
+uint16_t currentFile = 0;           //File index (per filesystem) of current file, relative to current directory (pointed to by currentDir)
+uint16_t maxFile = 0;                    //Total number of files in directory
+uint16_t oldMinFile = 0;
+uint16_t oldMaxFile = 0;
 #define fnameLength  5
 char oldMinFileName[fnameLength];
 char oldMaxFileName[fnameLength];
@@ -196,8 +194,7 @@ unsigned long timeDiff = 0;         //button debounce
     byte timeout_reset = TIMEOUT_RESET;
 #endif
 
-byte REWIND = 0;                      //Next File, down button pressed
-char PlayBytes[subdirLength];
+char PlayBytes[17];
 
 unsigned long blockOffset[maxblock];
 byte blockID[maxblock];
@@ -290,15 +287,6 @@ void setup() {
   #endif
   
   pinMode(chipSelect, OUTPUT);      //Setup SD card chipselect pin
-//  if (!sd.begin(chipSelect,SPI_FULL_SPEED)) {
-     //Start SD card and check it's working
-//    printtextF(PSTR("No SD Card"),0);
-    //lcd_clearline(0);
-    //lcd.print(F("No SD Card"));
-//    return;
-//    delay(250);
-//  } 
-
     while (!sd.begin(chipSelect,SPI_FULL_SPEED)) {
      //Start SD card and check it's working
       printtextF(PSTR("No SD Card"),0);
@@ -308,7 +296,7 @@ void setup() {
 //    delay(250);
     }    
   
-  //sd.chdir("/");                       //set SD to root directory
+  changeDirRoot();
   UniSetup();                       //Setup TZX specific options
     
  //printtext(VERSION,0);
@@ -330,12 +318,11 @@ void setup() {
 /*
   #ifdef SHOW_DIRNAMES
     oldMaxFile=maxFile;
-    REWIND=1;
     seekFile(oldMaxFile);
     str4cpy(oldMaxFileName,fileName);
   #endif
 */  
-  seekFile(currentFile);            //move to the first file in the directory
+  seekFile();            //move to the first file in the directory
 /*
   #ifdef SHOW_DIRNAMES
     str4cpy(oldMinFileName,fileName);
@@ -814,17 +801,11 @@ void loop(void) {
               #endif
 
           #else             
-             subdir=0;            
-             /*
-             prevSubDir[0][0]='\0';
-             prevSubDir[1][0]='\0';
-             prevSubDir[2][0]='\0';
-             */
-             for(int i=0;i<nMaxPrevSubDirs;i++) prevSubDir[i][0]='\0';
-             sd.chdir("/");
+             subdir=0;
+             changeDirRoot();
              getMaxFile();
-             currentFile=1;
-             seekFile(currentFile);
+             currentFile=0;
+             seekFile();
           #endif         
        #endif
 
@@ -857,81 +838,7 @@ void loop(void) {
        #if (SPLASH_SCREEN && TIMEOUT_RESET)
             timeout_reset = TIMEOUT_RESET;
        #endif     
-       fileName[0]='\0';
-       subdir--;
-       prevSubDir[subdir][0]='\0'; 
-
-       if (subdir==0)strcat(fileName,"/");
-       else {
-         for(int i=0;i<=subdir-1;i++) {
-          strcat(fileName,"/");
-          strcat(fileName,prevSubDir[i]);
-         }
-       }
-       sd.chdir(fileName);
-/*
-       switch(subdir){
-        case 0:
-           //sprintf(fileName,"%s",prevSubDir[0]);
-           sd.chdir("/");
-           break;
-        case 1:
-           //sprintf(fileName,"%s%s",prevSubDir[0],prevSubDir[1]);
-           sd.chdir(strcat(strcat(fileName,"/"),prevSubDir[0]));
-           break;
-        case 2:
-        default:
-           //sprintf(fileName,"%s%s/%s",prevSubDir[0],prevSubDir[1],prevSubDir[2]);
-           subdir = 2;
-           sd.chdir(strcat(strcat(strcat(strcat(fileName,"/"),prevSubDir[0]),"/"),prevSubDir[1]));
-           break;
-    //   case 3:
-       //default:
-           //sprintf(fileName,"%s%s/%s/%s",prevSubDir[0],prevSubDir[1],prevSubDir[2],prevSubDir[3]);
-           //subdir = 3;
-        //   sd.chdir(strcat(strcat(strcat(strcat(strcat(strcat(fileName,"/"),prevSubDir[0]),"/"),prevSubDir[1]),"/"),prevSubDir[2]),true); 
-        //   break;        
-       }
-*/
-       //Return to prev Dir of the SD card.
-       //sd.chdir(fileName,true);
-       //sd.chdir("/CDT");       
-       //printtext(prevDir,0); //debug back dir
-       
-       getMaxFile();
-       //currentFile=1;
-       currentFile=DirFilePos[subdir];
-       oldMinFile =1;   // Check and activate when new space for OLED
-       
-/*          PlayBytes[0]='\0'; itoa(currentFile,PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000);
-          PlayBytes[0]='\0'; itoa(DirFilePos[0],PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000);
-          PlayBytes[0]='\0'; itoa(DirFilePos[1],PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000);
-          PlayBytes[0]='\0'; itoa(DirFilePos[2],PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000); */
-
-       REWIND=1;
-       seekFile(currentFile);
-       DirFilePos[subdir]=0;
-
-    /*      PlayBytes[0]='\0'; itoa(currentFile,PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000);
-          PlayBytes[0]='\0'; itoa(DirFilePos[0],PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000);
-          PlayBytes[0]='\0'; itoa(DirFilePos[1],PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000);
-          PlayBytes[0]='\0'; itoa(DirFilePos[2],PlayBytes,10); 
-          printtext(PlayBytes,0);
-          delay(1000); */
+       changeDirParent();
 
        debounce(btnStop);   
 /*       while(digitalRead(btnStop)==LOW) {
@@ -1346,28 +1253,40 @@ void debouncemax(int boton){
 }
 
 void upFile() {    
-  //move up a file in the directory
-  oldMinFile = 1;
+  // move up a file in the directory.
+  // find prior index, using currentFile.
+  oldMinFile = 0;
   oldMaxFile = maxFile;
-  
-  currentFile--;
-  if(currentFile<1) {
-    getMaxFile();
+  while(currentFile!=0)
+  {
+    currentFile--;
+    // currentFile might not point to a valid entry (since not all values are used)
+    // and we might need to go back a bit further
+    // Do this here, so that we only need this logic in one place
+    // and so we can make seekFile dumber
+    entry.close();
+    if (entry.open(&currentDir, currentFile, O_RDONLY))
+    {
+      entry.close();
+      break;
+    }
+  }
+
+  if(currentFile==0)
+  {
+    // seek up wrapped - should now be reset to point to the last file
     currentFile = maxFile;
   }
-  REWIND=1;   
-  seekFile(currentFile);
+  seekFile();
 }
 
 void downFile() {    
   //move down a file in the directory
-  oldMinFile = 1;
+  oldMinFile = 0;
   oldMaxFile = maxFile;
-  
   currentFile++;
-  if(currentFile>maxFile) { currentFile=1; }
-  REWIND=0;  
-  seekFile(currentFile);
+  if (currentFile>maxFile) { currentFile=0; }
+  seekFile();
 }
 
 void upHalfSearchFile() {    
@@ -1381,9 +1300,7 @@ void upHalfSearchFile() {
     #endif
 */
     currentFile = oldMinFile + (oldMaxFile - oldMinFile)/2;
-    
-    REWIND=1;   
-    seekFile(currentFile);
+    seekFile();
   }
 }
 
@@ -1398,42 +1315,36 @@ void downHalfSearchFile() {
     #endif
 */    
     currentFile = oldMinFile + 1+ (oldMaxFile - oldMinFile)/2;
-  
-    REWIND=1;  
-    seekFile(currentFile);
+    seekFile();
   } 
 }
 
-void seekFile(int pos) {    
+void seekFile() {    
   //move to a set position in the directory, store the filename, and display the name on screen.
-  if (REWIND==1) {  
-    RewindSD();
-    for(int i=1;i<=pos-1;i++) {
-
-      entry.openNext(entry.cwd(),O_READ);
-      entry.close();
-
-    }
+  entry.close(); // precautionary, and seems harmless if entry is already closed
+  
+  while (!entry.open(&currentDir, currentFile, O_RDONLY))
+  {
+    // if entry.open fails, when given an index, sdfat 2.1.2 automatically adjust curPosition to the next good entry
+    // (which means that we can just retry calling open, passing in curPosition)
+    // but sdfat 1.1.4 does not automatically adjust curPosition, so we cannot do that trick.
+    // We cannot call openNext, because (with sdfat 2.1.2) the position has ALREADY been adjusted, so you will actually
+    // miss a file.
+    // so need to do this manually (to support both library versions), via incrementing currentFile manually
+    currentFile++;
   }
 
-  if (pos==1) {RewindSD();}
-
-  entry.openNext(entry.cwd(),O_READ);
   entry.getName(fileName,filenameLength);
-  entry.getSFN(sfileName);
-
   filesize = entry.fileSize();
   #ifdef AYPLAY
   ayblklen = filesize + 3;  // add 3 file header, data byte and chksum byte to file length
   #endif
-  if(entry.isDir() || !strcmp(sfileName, "ROOT")) { isDir=1; } else { isDir=0; }
+  if(entry.isDir() || !strcmp(fileName, "ROOT")) { isDir=1; } else { isDir=0; }
   entry.close();
 
   PlayBytes[0]='\0'; 
   if (isDir==1) {
- //   strcat_P(PlayBytes,PSTR(VERSION));
-    //if (subdir >0)strncpy(PlayBytes,prevSubDir[subdir-1],16);
-    if (subdir >0)strcpy(PlayBytes,prevSubDir[subdir-1]);
+    if (subdir >0)strcpy(PlayBytes,prevSubDir);
     else strcat_P(PlayBytes,PSTR(VERSION));
 /*
        else { itoa(oldMinFile,input,10); strcpy(PlayBytes,input);strcat(PlayBytes,"-");
@@ -1453,8 +1364,6 @@ void seekFile(int pos) {
 
   //PlayBytes[0]='\0'; itoa(DirFilePos[0],PlayBytes,10); 
   printtext(PlayBytes,0);
-  //printtext(prevSubDir[0],0);
-
   
   scrollPos=0;
   scrollText(fileName);
@@ -1481,9 +1390,24 @@ void playFile() {
   if(isDir==1) {
     //If selected file is a directory move into directory
     changeDir();
-  } else {
-
-    if(entry.cwd()->exists(sfileName)) {
+  }
+  else if (fileName[0] == '\0') 
+  {
+    #ifdef LCDSCREEN16x2
+      printtextF(PSTR("No File Selected"),1);
+    #endif      
+    #ifdef OLED1306
+      printtextF(PSTR("No File Selected"),lineaxy);
+    #endif
+    #ifdef P8544
+      printtextF(PSTR("No File Selected"),1);
+    #endif
+    
+    //lcd_clearline(1);
+    //lcd.print(F("No File Selected"));
+  }
+  else
+  {
       printtextF(PSTR("Playing"),0);
       //printtext(PlayBytes,0);
       //lcd_clearline(0);
@@ -1493,94 +1417,91 @@ void playFile() {
       scrollText(fileName);
       currpct=100;
       lcdsegs=0;
-      UniPlay(sfileName);           //Load using the short filename
+      UniPlay();
         #ifdef P8544
           lcd.gotoRc(3,38);
           lcd.bitmap(Play, 1, 6);
         #endif      
       start=1;       
     }    
-
-      else {
-      #ifdef LCDSCREEN16x2
-        printtextF(PSTR("No File Selected"),1);
-      #endif      
-      #ifdef OLED1306
-        printtextF(PSTR("No File Selected"),lineaxy);
-      #endif
-      #ifdef P8544
-        printtextF(PSTR("No File Selected"),1);
-      #endif
-      
-      //lcd_clearline(1);
-      //lcd.print(F("No File Selected"));
-    }
-  }
 }
 
 void getMaxFile() {    
-  //gets the total files in the current directory and stores the number in maxFile
-  
-  RewindSD();
-  maxFile=0;
-  while(entry.openNext(entry.cwd(),O_READ)) {
-    //entry.getName(fileName,filenameLength);
+  // gets the total files in the current directory and stores the number in maxFile
+  // and also gets the file index of the last file found in this directory
+  currentDir.rewind();
+  maxFile = 0;
+  while(entry.openNext(&currentDir, O_RDONLY)) {
+    maxFile = currentDir.curPosition()/32-1;
     entry.close();
-    maxFile++;
   }
-
+  currentDir.rewind(); // precautionary but I think might be unnecessary since we're using currentFile everywhere else now
   oldMaxFile = maxFile;
-  //entry.cwd()->rewind();
 }
 
-
-
 void changeDir() {    
-  //change directory, if fileName="ROOT" then return to the root directory
-  //SDFat has no easy way to move up a directory, so returning to root is the easiest way. 
-  //each directory (except the root) must have a file called ROOT (no extension)
+  // change directory (to whatever is currently the selected fileName)
+  // if fileName="ROOT" then return to the root directory
                       
-  if(!strcmp(fileName, "ROOT")) {
+  if(!strcmp(fileName, "ROOT"))
+  {
     subdir=0;    
-    sd.chdir("/");
+    changeDirRoot();
   } else {
      //if (subdir >0) entry.cwd()->getName(prevSubDir[subdir-1],filenameLength); // Antes de cambiar
      if (subdir < nMaxPrevSubDirs) {
-       DirFilePos[subdir] = currentFile;
-       sd.chdir(fileName);
-       if (strlen(fileName) > subdirLength) {
-        //entry.getSFN(sfileName);
-        strcpy(prevSubDir[subdir], sfileName);
-       }
-       else {
-        strcpy(prevSubDir[subdir], fileName);
-       }
-       
-       //entry.cwd()->getName(prevSubDir[subdir],filenameLength);
-       //entry.getSFN(sfileName);
-       //strcpy(prevSubDir[subdir], sfileName);
-       //strcpy(prevSubDir[subdir], fileName);
-       
-       subdir++;  
-     }    
+      DirFilePos[subdir] = currentFile;
+      subdir++;
+      // but, also, stash the current filename as the parent (prevSubDir) for display
+      // (but we only keep one prevSubDir, we no longer need to store them all)
+      fileName[SCREENSIZE] = '\0';
+      strcpy(prevSubDir, fileName);
+    }
+    tmpdir.open(&currentDir, currentFile, O_RDONLY);
+    currentDir = tmpdir;
+    tmpdir.close();
   }
   getMaxFile();
-/*
-  #ifdef SHOW_DIRNAMES
-    oldMaxFile=maxFile;  
-    REWIND=1;
-    seekFile(oldMaxFile);
-    str4cpy(oldMaxFileName,fileName);    
-  #endif
-*/
-  oldMinFile=1;  // Cheack and activate when new space for OLED
-  currentFile=1;
-  seekFile(currentFile);
-/*
-  #ifdef SHOW_DIRNAMES
-    str4cpy(oldMinFileName,fileName);
-  #endif
-*/  
+  currentFile=0;
+  oldMinFile=0;
+  seekFile();
+}
+
+void changeDirParent()
+{
+  // change up to parent directory.
+  // get to parent folder via re-navigating the same sequence of directories, starting at root
+  // (slow-ish but, honestly, not very slow. and requires very little memory to keep a deep stack of parents
+  // since you only need to store one file index, not a whole filename, for each directory level)
+  // Note to self : does sdfat now support any better way of doing this e.g. is there a link back to parent like ".."  ?
+  subdir--;
+  uint16_t this_directory=DirFilePos[subdir]; // remember what directory we are in currently
+
+  changeDirRoot();
+  if(subdir>0)
+  {
+    for(int i=0; i<subdir; i++)
+    {
+      tmpdir.open(&currentDir, DirFilePos[i], O_RDONLY);
+      currentDir = tmpdir;
+      tmpdir.close();
+    }
+    // get the filename of the last directory we opened, because this is now the prevSubDir for display
+    currentDir.getName(fileName, filenameLength);
+    fileName[SCREENSIZE] = '\0'; // copy only the piece we need. small cheat here - we terminate the string where we want it to end...
+    strcpy(prevSubDir, fileName);
+  }
+   
+  getMaxFile();
+  currentFile = this_directory; // select the directory we were in, as the current file in the parent
+  oldMinFile=0;
+  seekFile(); // don't forget that this will put the real filename back into fileName 
+}
+
+void changeDirRoot()
+{
+  currentDir.close();
+  currentDir.open("/", O_RDONLY);                    //set SD to root directory
 }
 
 void scrollText(char* text){
@@ -2062,7 +1983,7 @@ void SetPlayBlock()
        //lcd.println(pos); lcd.print(" ");
        //stopFile();
        //playFile(); 
-       //TZXPlay(sfileName);           //Load using the short filename
+       //TZXPlay();
 
        //reset data block values
        //clearBuffer();
@@ -2075,24 +1996,17 @@ void SetPlayBlock()
               
 
 /*
-       entry.getSFN(sfileName);
-
        currentBlockTask = READPARAM;               //First block task is to read in parameters
        //currentTask=PROCESSID;
        //currentID=TAP;
        currentTask=GETFILEHEADER;                  //First task: search for header
-       checkForEXT(sfileName);
 */
 
 
-//  entry.getSFN(sfileName);
-  
-  
 //  Timer1.stop();                              //Stop timer interrupt
 
 //  bytesRead=0;                                //start of file
 
-  //checkForEXT (sfileName);
   if (!casduino) {
     currentBlockTask = READPARAM;               //First block task is to read in parameters
 //    clearBuffer2();                               // chick sound with CASDUINO clearBuffer()
@@ -2255,27 +2169,12 @@ void str4cpy (char *dest, char *src)
   dest[4]=0; 
 }
 
-void GetFileName (int pos)
+void GetFileName(uint16_t pos)
 {
-  RewindSD();
-  for(int i=1;i<=pos-1;i++) {
-
-    entry.openNext(entry.cwd(),O_READ);
-    entry.close();
-
+  entry.close(); // precautionary, and seems harmless if entry is already closed
+  if (entry.open(&currentDir, pos, O_RDONLY))
+  {
+    entry.getName(fileName,filenameLength);
   }
-  //if (pos==1) {entry.cwd()->rewind();}
-
-  entry.openNext(entry.cwd(),O_READ);
-  entry.getName(fileName,filenameLength);
-  //entry.getSFN(sfileName);
   entry.close();
-  //scrollPos=0;
-  //scrollText(fileName);
-
-}
-
-void RewindSD()
-{
-  entry.cwd()->rewind();
 }

--- a/MaxProcessing.ino
+++ b/MaxProcessing.ino
@@ -7,7 +7,7 @@ word TickToUs(word ticks) {
   return (word)((((long(ticks) << 2) + 7) >> 1) / 7);
 }
 
-void UniPlay(char *filename){
+void UniPlay(){
   setBaud();
 //  #if defined(__AVR__)
 //    Timer1.stop();                              //Stop timer interrupt
@@ -15,7 +15,9 @@ void UniPlay(char *filename){
 //    timer.pause();
 //  #endif
 
-  if(!entry.open(filename,O_READ)) {
+  // on entry, currentFile is already pointing to the file entry you want to play
+  // and fileName is already set
+  if(!entry.open(&currentDir, currentFile, O_RDONLY)) {
   //  printtextF(PSTR("Error Opening File"),0);
   }
 
@@ -36,7 +38,7 @@ void UniPlay(char *filename){
   //char x =0;
   //while (*(filename+x) && (*(filename+x) != '.')) x++;
   //checkForEXT (filename+x);
-  char *lastdotptr= strrchr(filename,'.');
+  char *lastdotptr= strrchr(fileName,'.');
   checkForEXT (lastdotptr);
  #ifdef ID11CDTspeedup  
   //if (!strcasecmp_P(filename + x, PSTR(".cdt"))) AMScdt = 1;
@@ -141,8 +143,7 @@ void TZXStop() {
   entry.close();                              //Close file                                                                                // DEBUGGING Stuff
   //lcd.setCursor(0,1);
   //lcd.print(blkchksum,HEX); lcd.print(F("ck ")); lcd.print(bytesRead); lcd.print(F(" ")); lcd.print(ayblklen);
-  REWIND=1;   
-  seekFile(currentFile); 
+  seekFile(); 
   bytesRead=0;                                // reset read bytes PlayBytes
   blkchksum = 0;                              // reset block chksum byte for AY loading routine
   AYPASS = 0;                                 // reset AY flag

--- a/casProcessing.ino
+++ b/casProcessing.ino
@@ -17,8 +17,7 @@ void casStop()
   start=0;
   //interrupts();
   entry.close();
-  //REWIND=1;   
-  seekFile(currentFile);
+  seekFile();
   bytesRead=0;
   dragonMode=0;
   casduino=0;

--- a/menu.ino
+++ b/menu.ino
@@ -2,11 +2,8 @@
 void menuMode()
  {
       //Return to root of the SD card.
-       sd.chdir(true);
-       getMaxFile();
-       currentFile=1;
-       seekFile(currentFile);  
-       while(digitalRead(btnMselect)==LOW) {
+      changeDirRoot();
+      while(digitalRead(btnMselect)==LOW) {
          //prevent button repeats by waiting until the button is released.
          delay(50);
        }


### PR DESCRIPTION
 for a small firmware size reduction (and a big speedup when navigating, especially "upwards")

I've kept the same filename size and number of subdirs, but with my changes here you already save over 100 bytes of ram too.  So you could increase the filename length to 256 and the number of subdirs to 10..