### PR TITLE
More cleanup

### DIFF
--- a/CounterPercent.ino
+++ b/CounterPercent.ino
@@ -25,7 +25,9 @@ void lcdTime() {
       else {
         // es 000,1000,2000,...
         lcd.setCursor(13,0);
-        lcd.print('0');lcd.print('0');lcd.print('0');
+        lcd.print('0');
+        lcd.print('0');
+        lcd.print('0');
       }
 
       lcdsegs++;
@@ -136,13 +138,25 @@ void lcdPercent() {
     #ifdef OLED1306
       #ifdef XY2force
         if (newpct <10) {
-          input[0]=48+(newpct%10);input[1]='%';input[2]=0;sendStrXY((char *)input,8,0);
+          input[0]=48+(newpct%10);
+          input[1]='%';
+          input[2]=0;
+          sendStrXY((char *)input,8,0);
         }
         else if (newpct <100) {
-          input[0]=48+(newpct/10);input[1]=48+(newpct%10);input[2]='%';input[3]=0;sendStrXY((char *)input,8,0);
+          input[0]=48+(newpct/10);
+          input[1]=48+(newpct%10);
+          input[2]='%';
+          input[3]=0;
+          sendStrXY((char *)input,8,0);
         }
         else {
-          input[0]='1';input[1]='0';input[2]='0'; input[3]='%';input[4]=0;sendStrXY((char *)input,8,0);
+          input[0]='1';
+          input[1]='0';
+          input[2]='0';
+          input[3]='%';
+          input[4]=0;
+          sendStrXY((char *)input,8,0);
         }
                                           
       #else // XY2force

--- a/Display.ino
+++ b/Display.ino
@@ -2,22 +2,16 @@
 #include "Logos.h"
 
 #if defined(OLED1306)
+  #include "i2c.h"
 
   //==========================================================//
   // Used to send commands to the display.
   static void sendcommand(unsigned char com)
   {
-    #if defined(Use_SoftI2CMaster)       
-      i2c_start((OLED_address<<1)|I2C_WRITE);
-      i2c_write(0x80);
-      i2c_write(com); 
-      i2c_stop();
-    #else            
-      Wire.beginTransmission(OLED_address); //begin transmitting
-      Wire.write(0x80); //command mode
-      Wire.write(com);
-      Wire.endTransmission(); // stop transmitting
-    #endif
+    mx_i2c_start(OLED_address); //begin transmitting
+    mx_i2c_write(0x80); //command mode
+    mx_i2c_write(com);
+    mx_i2c_end(); // stop transmitting
   }
 
   //==========================================================//
@@ -25,17 +19,10 @@
   // Display's chars uses 8 byte font
   static void SendByte(unsigned char data)
   {
-    #if defined(Use_SoftI2CMaster)       
-      i2c_start((OLED_address<<1)|I2C_WRITE); 
-      i2c_write(0x40); 
-      i2c_write(data); 
-      i2c_stop();
-    #else                   
-      Wire.beginTransmission(OLED_address); // begin transmitting
-      Wire.write(0x40);//data mode
-      Wire.write(data);
-      Wire.endTransmission(); // stop transmitting
-    #endif
+    mx_i2c_start(OLED_address); //begin transmitting
+    mx_i2c_write(0x40); //data mode
+    mx_i2c_write(data);
+    mx_i2c_end(); // stop transmitting
   }
 
   //==========================================================//
@@ -44,54 +31,30 @@
   // and 8 ROWS (0-7).
   static void sendChar(unsigned char data)
   {
-    #if defined(Use_SoftI2CMaster)       
-      i2c_start((OLED_address<<1)|I2C_WRITE);
-      i2c_write(0x40);
-      for(int i=0;i<8;i++) {
-        i2c_write(pgm_read_byte(myFont[data-0x20]+i));
-      }
-      i2c_stop();
-    #else                   
-      Wire.beginTransmission(OLED_address); // begin transmitting
-      Wire.write(0x40);//data mode
-      for(int i=0;i<8;i++) {
-        Wire.write(pgm_read_byte(myFont[data-0x20]+i));
-      }
-      Wire.endTransmission(); // stop transmitting
-    #endif
+    mx_i2c_start(OLED_address);
+    mx_i2c_write(0x40);
+    for(int i=0;i<8;i++) {
+      mx_i2c_write(pgm_read_byte(myFont[data-0x20]+i));
+    }
+    mx_i2c_end();
   } 
 
   //==========================================================//
   // Set the cursor position in a 16 COL * 2 ROW map.
   static void setXY(unsigned char col,unsigned char row)
   {
-    #if defined(Use_SoftI2CMaster)       
-      i2c_start((OLED_address<<1)|I2C_WRITE);
-      i2c_write(0x80);  
-      i2c_write(0xb0+(row)); //set page address (row)
-      i2c_write(0x80); //command mode
-      #ifdef OLED1106_1_3            
-        i2c_write(0x02+(8*col&0x0f)); //set low col address
-      #else
-        i2c_write(0x00+(8*col&0x0f)); //set low col address
-      #endif
-      i2c_write(0x80); 
-      i2c_write(0x10+((8*col>>4)&0x0f)); //set high col address 
-      i2c_stop();         
-    #else                              
-      Wire.beginTransmission(OLED_address); //begin transmitting
-      Wire.write(0x80); //command mode
-      Wire.write(0xb0+(row)); //set page address (row)
-      Wire.write(0x80); //command mode
-      #ifdef OLED1106_1_3            
-        Wire.write(0x02+(8*col&0x0f)); //set low col address
-      #else
-        Wire.write(0x00+(8*col&0x0f)); //set low col address
-      #endif
-      Wire.write(0x80); //command mode   
-      Wire.write(0x10+((8*col>>4)&0x0f)); //set high col address   
-      Wire.endTransmission(); // stop transmitting                 
+    mx_i2c_start(OLED_address);
+    mx_i2c_write(0x80);  
+    mx_i2c_write(0xb0+(row)); //set page address (row)
+    mx_i2c_write(0x80); //command mode
+    #ifdef OLED1106_1_3            
+      mx_i2c_write(0x02+(8*col&0x0f)); //set low col address
+    #else
+      mx_i2c_write(0x00+(8*col&0x0f)); //set low col address
     #endif
+    mx_i2c_write(0x80); 
+    mx_i2c_write(0x10+((8*col>>4)&0x0f)); //set high col address 
+    mx_i2c_end();         
   }   
 
   //==========================================================//
@@ -133,14 +96,8 @@
 
       setXY(Xl,Y);
       while(*stringL) {
-        #if defined(Use_SoftI2CMaster)       
-          i2c_start((OLED_address<<1)|I2C_WRITE);
-          i2c_write(0x40);
-        #else                  
-          Wire.beginTransmission(OLED_address); // begin transmitting
-          Wire.setClock(I2CCLOCK);     
-          Wire.write(0x40);//data mode
-        #endif
+        mx_i2c_start(OLED_address);
+        mx_i2c_write(0x40);
 
         for(int i=0;i<8;i++){
           int il=0;
@@ -153,33 +110,18 @@
             }
           }
   
-          #if defined(Use_SoftI2CMaster)           
-            i2c_write(il);
-          #else          
-            Wire.write(il);
-          #endif
+          mx_i2c_write(il);
         }
 
-        #if defined(Use_SoftI2CMaster) 
-          i2c_stop();
-        #else       
-          Wire.endTransmission(); // stop transmitting
-        #endif   
-
+        mx_i2c_end();
         Xl++;    
         stringL++;
       }
     
       setXY(Xh,Y+1);
       while(*stringH){      
-        #if defined(Use_SoftI2CMaster) 
-          i2c_start((OLED_address<<1)|I2C_WRITE);
-          i2c_write(0x40);           
-        #else
-          Wire.beginTransmission(OLED_address); // begin transmitting
-          Wire.setClock(I2CCLOCK);
-          Wire.write(0x40);//data mode        
-        #endif
+        mx_i2c_start(OLED_address);
+        mx_i2c_write(0x40);           
         
         for(int i=0;i<8;i++){
           int ih=0;
@@ -191,19 +133,10 @@
               ih |= (1 << ((ic-4)*2)+1);
             }   
           }
-          #if defined(Use_SoftI2CMaster)           
-            i2c_write(ih);
-          #else            
-            Wire.write(ih);
-          #endif
+          mx_i2c_write(ih);
         }
 
-        #if defined(Use_SoftI2CMaster)       
-          i2c_stop();
-        #else      
-          Wire.endTransmission(); // stop transmitting
-        #endif
-      
+        mx_i2c_end();
         Xh++;    
         stringH++;
       }
@@ -216,57 +149,27 @@
   
     setXY(Xl,Y);
     while(*stringL) {
-      #if defined(Use_SoftI2CMaster)       
-        i2c_start((OLED_address<<1)|I2C_WRITE);
-        i2c_write(0x40); 
-      #else            
-        Wire.beginTransmission(OLED_address); // begin transmitting
-        Wire.setClock(I2CCLOCK);
-        Wire.write(0x40);//data mode
-      #endif
+      mx_i2c_start(OLED_address);
+      mx_i2c_write(0x40); 
     
       for(int i=0;i<8;i++){
         int ril=(pgm_read_byte(myFont[*stringL-0x20]+i));
-        #if defined(Use_SoftI2CMaster)          
-          i2c_write(ril);
-        #else          
-          Wire.write(ril);
-        #endif 
+        mx_i2c_write(ril);
       }
-      #if defined(Use_SoftI2CMaster)       
-        i2c_stop(); 
-      #else        
-        Wire.endTransmission(); // stop transmitting
-      #endif
-    
+      mx_i2c_end();
       Xl++;    
       stringL++;
     }
   
     setXY (Xh,Y+1);
     while(*stringH) {
-      #if defined(Use_SoftI2CMaster)        
-        i2c_start((OLED_address<<1)|I2C_WRITE);
-        i2c_write(0x40); 
-      #else                 
-        Wire.beginTransmission(OLED_address); // begin transmitting
-        Wire.setClock(I2CCLOCK);
-        Wire.write(0x40);//data mode 
-      #endif    
+      mx_i2c_start(OLED_address);
+      mx_i2c_write(0x40); 
       for(int i=0;i<8;i++){
         int rih=(pgm_read_byte(myFont[*stringH-0x20]+i+8));
-        #if defined(Use_SoftI2CMaster)           
-          i2c_write(rih);
-        #else            
-          Wire.write(rih);
-        #endif         
+        mx_i2c_write(rih);
       }
-      #if defined(Use_SoftI2CMaster)       
-        i2c_stop();
-      #else        
-        Wire.endTransmission(); // stop transmitting
-      #endif
-    
+      mx_i2c_end();
       Xh++;    
       stringH++;
     }

--- a/Display.ino
+++ b/Display.ino
@@ -401,11 +401,7 @@
         #endif
 
         #if defined(RECORD_EEPROM_LOGO) && not defined(EEPROM_LOGO_COMPRESS)
-          #if defined(__AVR__) 
-            EEPROM.put(j*128+i, pgm_read_byte(logo+j*128+i));
-          #elif defined(__arm__) && defined(__STM32F1__)
-            EEPROM_put(j*128+i, pgm_read_byte(logo+j*128+i));
-          #endif      
+          EEPROM_put(j*128+i, pgm_read_byte(logo+j*128+i));
         #endif
 
         #if defined(RECORD_EEPROM_LOGO) && defined(EEPROM_LOGO_COMPRESS)
@@ -430,29 +426,18 @@
                     nh |= (1 << nc);
                   }
                 }
-                #if defined(__AVR__)             
-                  EEPROM.put((j/2)*64+i/2,nl+nh*16);
-                #elif defined(__arm__) && defined(__STM32F1__)
-                  EEPROM_put((j/2)*64+i/2,nl+nh*16);
-                #endif                          
+
+                EEPROM_put((j/2)*64+i/2,nl+nh*16);
               } 
 
             #else
-              #if defined(__AVR__)     
-                EEPROM.put(j*64+i/2, pgm_read_byte(logo+j*128+i));
-              #elif defined(__arm__) && defined(__STM32F1__)
-                EEPROM_put(j*64+i/2, pgm_read_byte(logo+j*128+i));
-              #endif
+              EEPROM_put(j*64+i/2, pgm_read_byte(logo+j*128+i));
             #endif
           }
         #endif   
 
         #if defined(LOAD_EEPROM_LOGO) && not defined(EEPROM_LOGO_COMPRESS)
-          #if defined(__AVR__)
-            EEPROM.get(j*128+i,hdrptr);
-          #elif defined(__arm__) && defined(__STM32F1__)
-            EEPROM_get(j*128+i,&hdrptr);
-          #endif
+          EEPROM_get(j*128+i, hdrptr);
           SendByte(hdrptr);
         #endif
 
@@ -463,11 +448,8 @@
                 byte il=0;
                 byte ril=0;
                 byte ib=0;
-                #if defined(__AVR__)
-                  EEPROM.get((j/2)*64+i/2,ril);
-                #elif defined(__arm__) && defined(__STM32F1__)
-                  EEPROM_get((j/2)*64+i/2,&ril);
-                #endif
+                EEPROM_get((j/2)*64+i/2, ril);
+
                 for(ib=0;ib<4;ib++) {
                   if (bitRead (ril,ib)) {
                     il |= (1 << ib*2);
@@ -481,11 +463,8 @@
                 byte ih=0;
                 byte rih=0;
                 byte ic=0;
-                #if defined(__AVR__) 
-                  EEPROM.get((j/2)*64+i/2,rih);
-                #elif defined(__arm__) && defined(__STM32F1__)
-                  EEPROM_get((j/2)*64+i/2,&rih);
-                #endif
+                EEPROM_get((j/2)*64+i/2, rih);
+
                 for(ic=4;ic<8;ic++) {
                   if (bitRead (rih,ic)) {
                     ih |= (1 << (ic-4)*2);
@@ -497,11 +476,7 @@
                 hdrptr = ih;                           
               }
             #else
-              #if defined(__AVR__)
-                EEPROM.get(j*64+i/2,hdrptr);
-              #elif defined(__arm__) && defined(__STM32F1__)
-                EEPROM_get(j*64+i/2,&hdrptr);
-              #endif
+              EEPROM_get(j*64+i/2, hdrptr);
             #endif
           }
           SendByte(hdrptr);

--- a/EEPROM.h
+++ b/EEPROM.h
@@ -1,0 +1,31 @@
+// platform-independent wrapper for common eeprom interface
+
+#ifndef EEPROM_H_INCLUDED
+#define EEPROM_H_INCLUDED
+
+#if defined(__AVR__)
+  #include <EEPROM.h>
+  #define EEPROM_put EEPROM.put
+  #define EEPROM_get EEPROM.get
+#elif defined(__arm__) && defined(__STM32F1__)
+
+  #include <EEPROM.h>
+  uint8_t EEPROM_get(uint16_t address, byte &data) {
+    if (EEPROM.init()==EEPROM_OK) {
+      data = (byte)(EEPROM.read(address) & 0xff);  
+      return true;  
+    } else 
+      return false;
+  }
+  
+
+  uint8_t EEPROM_put(uint16_t address, byte data) {
+    if (EEPROM.init()==EEPROM_OK) {
+      EEPROM.write(address, (uint16_t) data); 
+      return true;    
+    } else
+      return false;
+  }
+#endif
+
+#endif // EEPROM_H_INCLUDED

--- a/MaxDuino.ino
+++ b/MaxDuino.ino
@@ -237,12 +237,9 @@ void setup() {
     Serial.begin(115200);
   #endif
   
-  #ifdef OLED1306 
-    #if defined(Use_SoftI2CMaster) 
-      i2c_init();
-    #else
-      Wire.begin();
-    #endif    
+  #ifdef OLED1306
+    #include "i2c.h"
+    mx_i2c_init();
     init_OLED();
     #if (!SPLASH_SCREEN)
       #if defined(LOAD_MEM_LOGO) || defined(LOAD_EEPROM_LOGO)

--- a/MaxDuino.ino
+++ b/MaxDuino.ino
@@ -157,7 +157,7 @@
 #include "buttons.h"
 
 #if defined(BLOCK_EEPROM_PUT) || defined(LOAD_EEPROM_LOGO) || defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_SETTINGS)
-#include <EEPROM.h>
+#include "EEPROM.h"
 #endif
 
 char fline[17];
@@ -1457,15 +1457,10 @@ void GetAndPlayBlock()
     currentID=blockID[block%maxblock];   
   #endif
   #ifdef BLOCK_EEPROM_PUT
-    #if defined(__AVR__)
-      EEPROM.get(BLOCK_EEPROM_START+5*block, bytesRead);
-      EEPROM.get(BLOCK_EEPROM_START+4+5*block, currentID);
-    #elif defined(__arm__) && defined(__STM32F1__)
-      EEPROM_get(BLOCK_EEPROM_START+5*block, &bytesRead);
-      EEPROM_get(BLOCK_EEPROM_START+4+5*block, &currentID);
-    #endif      
- #endif
- #ifdef BLOCKID_NOMEM_SEARCH 
+    EEPROM_get(BLOCK_EEPROM_START+5*block, bytesRead);
+    EEPROM_get(BLOCK_EEPROM_START+4+5*block, currentID);
+  #endif
+  #ifdef BLOCKID_NOMEM_SEARCH 
     unsigned long oldbytesRead;           //TAP
     bytesRead=0;                          //TAP 
     if (currentID!=TAP) bytesRead=10;   //TZX with blocks skip TZXHeader

--- a/MaxProcessing.ino
+++ b/MaxProcessing.ino
@@ -1358,16 +1358,7 @@ void TZXProcess() {
         } else {
           if (forcePause0) { // Stop the Tape
             if(!count==0) {
-
-            #if defined(__AVR__) || defined(__SAMD21__)
               currentPeriod = 32769;
-              //currentPeriod = 50;
-            #elif defined(__arm__) && defined(__STM32F1__)
-              currentPeriod = 50;
-            #else
-              #error unknown timer
-            #endif
-
               count += -1;
             } else {
               currentTask = GETID;
@@ -1384,17 +1375,9 @@ void TZXProcess() {
       case IDEOF:
         //Handle end of file
         if(!count==0) {
-          #if defined(__AVR__) || defined(__SAMD21__)
-            currentPeriod = 10;
-            bitSet(currentPeriod, 15);
-            bitSet(currentPeriod, 13);
-            
-          #elif defined(__arm__) && defined(__STM32F1__)
-            currentPeriod = 50;
-          #else
-            #error unknown timer
-          #endif
-                
+          currentPeriod = 10;
+          bitSet(currentPeriod, 15);
+          bitSet(currentPeriod, 13);
           count += -1;
         } else {
           stopFile();
@@ -2345,18 +2328,9 @@ void ReadUEFHeader() {
 #endif
 void DelayedStop() {
   if(!count==0) {
-  
-  #if defined(__AVR__) || defined(__SAMD21__)
     currentPeriod = 10;
     bitSet(currentPeriod, 15); 
     bitSet(currentPeriod, 13);
-    
-  #elif defined(__arm__) && defined(__STM32F1__)
-    currentPeriod = 50;
-  #else
-    #error unknown timer
-  #endif
-          
     count += -1;
   } else {
     stopFile();

--- a/MaxProcessing.ino
+++ b/MaxProcessing.ino
@@ -354,13 +354,8 @@ void TZXProcess() {
               blockID[block%maxblock] = currentID;
             #endif
             #ifdef BLOCK_EEPROM_PUT
-              #if defined(__AVR__)
-                EEPROM.put(BLOCK_EEPROM_START+5*block, bytesRead);
-                EEPROM.put(BLOCK_EEPROM_START+4+5*block, currentID);
-              #elif defined(__arm__) && defined(__STM32F1__)
-                EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
-                EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
-              #endif                
+              EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
+              EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
             #endif
         
             #if defined(OLED1306) && defined(OLEDPRINTBLOCK) 
@@ -450,13 +445,8 @@ void TZXProcess() {
             #endif
         
             #ifdef BLOCK_EEPROM_PUT
-              #if defined(__AVR__)
-                EEPROM.put(BLOCK_EEPROM_START+5*block, bytesRead);
-                EEPROM.put(BLOCK_EEPROM_START+4+5*block, currentID);
-              #elif defined(__arm__) && defined(__STM32F1__)
-                EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
-                EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
-              #endif                
+              EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
+              EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
             #endif
             
             #if defined(OLED1306) && defined(OLEDPRINTBLOCK)
@@ -673,13 +663,8 @@ void TZXProcess() {
                 blockID[block%maxblock] = currentID;
               #endif
               #ifdef BLOCK_EEPROM_PUT
-                #if defined(__AVR__)
-                  EEPROM.put(BLOCK_EEPROM_START+5*block, bytesRead);
-                  EEPROM.put(BLOCK_EEPROM_START+4+5*block, currentID);
-                #elif defined(__arm__) && defined(__STM32F1__)
-                  EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
-                  EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
-                #endif                   
+                EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
+                EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
               #endif
 
               #if defined(OLED1306) && defined(OLEDPRINTBLOCK)
@@ -781,13 +766,8 @@ void TZXProcess() {
             blockID[block%maxblock] = currentID;
           #endif
           #if defined(BLOCK_EEPROM_PUT)
-            #if defined(__AVR__)
-              EEPROM.put(BLOCK_EEPROM_START+5*block, bytesRead);
-              EEPROM.put(BLOCK_EEPROM_START+4+5*block, currentID);
-            #elif defined(__arm__) && defined(__STM32F1__)
-              EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
-              EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID); 
-            #endif                
+            EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
+            EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID); 
           #endif
           #if defined(OLED1306) && defined(OLEDPRINTBLOCK)
             #ifdef XY
@@ -947,13 +927,8 @@ void TZXProcess() {
               blockID[block%maxblock] = currentID;
             #endif
             #ifdef BLOCK_EEPROM_PUT
-              #if defined(__AVR__)
-                EEPROM.put(BLOCK_EEPROM_START+5*block, bytesRead);
-                EEPROM.put(BLOCK_EEPROM_START+4+5*block, currentID);
-              #elif defined(__arm__) && defined(__STM32F1__)
-                EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
-                EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
-              #endif                 
+              EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
+              EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID);
             #endif
             
             #if defined(OLED1306) && defined(OLEDPRINTBLOCK)
@@ -1101,13 +1076,8 @@ void TZXProcess() {
                 blockID[block%maxblock] = currentID;
               #endif
               #if defined(BLOCK_EEPROM_PUT)
-                #if defined(__AVR__)
-                  EEPROM.put(BLOCK_EEPROM_START+5*block, bytesRead);
-                  EEPROM.put(BLOCK_EEPROM_START+4+5*block, currentID);
-                #elif defined(__arm__) && defined(__STM32F1__)
-                  EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
-                  EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID); 
-                #endif                 
+                EEPROM_put(BLOCK_EEPROM_START+5*block, bytesRead);
+                EEPROM_put(BLOCK_EEPROM_START+4+5*block, currentID); 
               #endif
               
               #if defined(OLED1306) && defined(OLEDPRINTBLOCK)

--- a/TimerCounter.h
+++ b/TimerCounter.h
@@ -281,6 +281,7 @@ class TimerCounter
 unsigned short TimerCounter::pwmPeriod = 0;
 unsigned char TimerCounter::clockSelectBits = 0;
 timerCallback TimerCounter::isrCallback = NULL;
+extern TimerCounter Timer;
 ISR(TCA0_OVF_vect)
 {
   Timer.isrCallback();

--- a/i2c.h
+++ b/i2c.h
@@ -1,0 +1,19 @@
+// wrappers around different i2c implementations to expose the same interface to library code
+
+#ifndef I2C_H_INCLUDED
+#define I2C_H_INCLUDED
+
+#if defined(Use_SoftI2CMaster)
+  #define mx_i2c_init() i2c_init()
+  #define mx_i2c_start(address) i2c_start((address<<1)|I2C_WRITE)
+  #define mx_i2c_write(byte) i2c_write(byte)
+  #define mx_i2c_end() i2c_stop()
+#else
+  #define mx_i2c_init() Wire.begin();\
+                        Wire.setClock(I2CCLOCK)
+  #define mx_i2c_start(address) Wire.beginTransmission(address)
+  #define mx_i2c_write(byte) Wire.write(byte)
+  #define mx_i2c_end() Wire.endTransmission()
+#endif
+
+#endif // I2C_H_INCLUDED

--- a/menu.ino
+++ b/menu.ino
@@ -17,25 +17,9 @@
  */
 #include "buttons.h"
 
-#if defined(__arm__) && defined(__STM32F1__)
-
-  uint8_t EEPROM_get(uint16_t address, byte *data) {
-    if (EEPROM.init()==EEPROM_OK) {
-      *data = (byte)(EEPROM.read(address) & 0xff);  
-      return true;  
-    } else 
-      return false;
-  }
-  
-
-  uint8_t EEPROM_put(uint16_t address, byte data) {
-    if (EEPROM.init()==EEPROM_OK) {
-      EEPROM.write(address, (uint16_t) data); 
-      return true;    
-    } else
-      return false;
-  }
-  #endif
+#if defined(LOAD_EEPROM_SETTINGS)
+#include "EEPROM.h"
+#endif
 
 enum MenuItems{
   BAUD_RATE,
@@ -277,22 +261,14 @@ void doOnOffSubmenu(const char * title, byte& refVar)
       if(skip2A) settings |=32;
     #endif
 
-    #if defined(__AVR__)
-      EEPROM.put(EEPROM_CONFIG_BYTEPOS,settings);
-    #elif defined(__arm__) && defined(__STM32F1__)
-      EEPROM_put(EEPROM_CONFIG_BYTEPOS,settings);
-    #endif      
+    EEPROM_put(EEPROM_CONFIG_BYTEPOS, settings);
     setBaud();
   }
 
   void loadEEPROM()
   {
     byte settings=0;
-    #if defined(__AVR__)
-      EEPROM.get(EEPROM_CONFIG_BYTEPOS,settings);
-    #elif defined(__arm__) && defined(__STM32F1__)
-      EEPROM_get(EEPROM_CONFIG_BYTEPOS,&settings);
-    #endif
+    EEPROM_get(EEPROM_CONFIG_BYTEPOS, settings);
         
     if(!settings) return;
     


### PR DESCRIPTION
Finally refactoring all the eeprom ifdefs.
I also saw a few final timer-related ifdefs but I cannot understand them.  Why should we (sometimes) have a different period for STM versus all others?  Could happen if some code got changed/fixed, but the fixes only propagated to one of the platforms, and not the others (not a good reason if true).  With this change, all the platforms have the same periods.  Guessing AVR is the most stable/tested, so I used those settings.
