### PR TITLE
Don't run autoversion workflow in forks either

### DIFF
--- a/.github/workflows/autoversion_on_commit.yaml
+++ b/.github/workflows/autoversion_on_commit.yaml
@@ -22,6 +22,9 @@ jobs:
     permissions:
       contents: write
       
+    # don't run in forks. only the main repo has automatic versioning, and if you autoupdate versions in forks (like branches) you'd get conflicts on version.h every time you merge
+    if: github.repository == 'rcmolina/MaxDuino'
+      
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
This is a bit funky but basically, only the primary repo rcmolina/MaxDuino should run the auto-version-numbering .
I just noticed this while adding stuff to the master branch in my fork, it updated version.h in my fork which we don't want. 
 (The only kind of manual change to version.h would be if I updated MAJOR.minor  -  which should be rare!).

Rather than manually throw my automatic version.h commits away, or suffer a tricky merge, this change should stop the autoversion running in forks of the primary repo.