### PR TITLE
Using enums for ids for tasks, blocktasks, cas types

### DIFF
--- a/CheckForExt.ino
+++ b/CheckForExt.ino
@@ -7,7 +7,7 @@ void checkForEXT(const char * const filenameExt) {
 #endif
 
   if (!strcasecmp_P(filenameExt, PSTR("tap"))) {
-    currentTask=PROCESSID;
+    currentTask=TASK::PROCESSID;
     currentID=TAP;
     #ifdef tapORIC
       readfile(1,bytesRead);
@@ -17,16 +17,16 @@ void checkForEXT(const char * const filenameExt) {
     #endif
   }
   else if (!strcasecmp_P(filenameExt, PSTR("p"))) {
-    currentTask=PROCESSID;
+    currentTask=TASK::PROCESSID;
     currentID=ZXP;
   }
   else if (!strcasecmp_P(filenameExt, PSTR("o"))) {
-    currentTask=PROCESSID;
+    currentTask=TASK::PROCESSID;
     currentID=ZXO;
   }
 #ifdef AYPLAY  
   else if (!strcasecmp_P(filenameExt, PSTR("ay"))) {
-    currentTask=GETAYHEADER;
+    currentTask=TASK::GETAYHEADER;
     currentID=AYO;
     AYPASS = 0;
     hdrptr = HDRSTART;
@@ -34,7 +34,7 @@ void checkForEXT(const char * const filenameExt) {
 #endif
 #ifdef Use_UEF
   else if (!strcasecmp_P(filenameExt, PSTR("uef"))) {
-    currentTask=GETUEFHEADER;
+    currentTask=TASK::GETUEFHEADER;
     currentID=UEF;
   }
 #endif

--- a/MaxDuino.ino
+++ b/MaxDuino.ino
@@ -1483,10 +1483,10 @@ void SetPlayBlock()
   pass=0;
 
 #ifdef Use_CAS
-  if (!casduino) // not a CAS / DRAGON file
+  if (casduino==CASDUINO_FILETYPE::NONE) // not a CAS / DRAGON file
 #endif
   {
-    currentBlockTask = READPARAM;               //First block task is to read in parameters
+    currentBlockTask = BLOCKTASK::READPARAM;               //First block task is to read in parameters
     Timer.setPeriod(1000);
   }
 }
@@ -1623,13 +1623,13 @@ void GetAndPlayBlock()
 
   bytesRead=oldbytesRead;
   if (currentID==TAP) {
-    currentTask=PROCESSID;
+    currentTask=TASK::PROCESSID;
   }else {
-    currentTask=GETID;    //Get new TZX Block
+    currentTask=TASK::GETID;    //Get new TZX Block
     if(ReadByte()) {
       //TZX with blocks GETID
       currentID = outByte;
-      currentTask=PROCESSID;
+      currentTask=TASK::PROCESSID;
     }
   }
    


### PR DESCRIPTION
Idea to use strongly-typed identifiers, rather than #define, to represent the different parts of the statemachine. No size change, this just helps the compiler to prevent mistakes better (e.g. if you accidentally tried to use IDPAUSE instead of TASK::PAUSE, or if you accidentally set currentTask=currentBlockTask or something like that - because these are now distinct types, the compiler will now be able to catch this and show error message)