### PR TITLE
Small changes to enable compilation with latest Sdfat library 2.2.3,

### DIFF
--- a/MaxProcessing.ino
+++ b/MaxProcessing.ino
@@ -11,7 +11,7 @@ void UniPlay(){
 
   // on entry, currentFile is already pointing to the file entry you want to play
   // and fileName is already set
-  if(!entry.open(&currentDir, currentFile, O_RDONLY)) {
+  if(!entry.open(currentDir, currentFile, O_RDONLY)) {
   //  printtextF(PSTR("Error Opening File"),0);
   }
 

--- a/power.ino
+++ b/power.ino
@@ -94,8 +94,9 @@ void power_off()
 
   // ensure SD is finished before we stop everything (common)
   entry.close();
-  currentDir.close();
-  tmpdir.close();
+  currentDir->close();
+  _tmpdirs[0].close();
+  _tmpdirs[1].close();
   sd.end();
 
   device_power_off();


### PR DESCRIPTION
in which copy construction is explicitly and intentionally prevented. Essentially, our code before was 'misusing' the API and creating copies of File objects, so I've reworked it to use pointer-to-File instead.